### PR TITLE
target/arm: Fix exclusive access

### DIFF
--- a/qemu/target/arm/helper-a64.c
+++ b/qemu/target/arm/helper-a64.c
@@ -553,7 +553,7 @@ static uint64_t do_paired_cmpxchg64_le(CPUARMState *env, uint64_t addr,
     assert(parallel && "unexpected non-parallel cmpxchg64_le"); // SNPS added
 
     if (parallel) {
-#ifndef CONFIG_CMPXCHG128 // SNPS changed
+#ifndef HAVE_CMPXCHG128 // SNPS changed
         cpu_loop_exit_atomic(env_cpu(env), ra);
 #else
         int mem_idx = cpu_mmu_index(env, false);
@@ -625,7 +625,7 @@ static uint64_t do_paired_cmpxchg64_be(CPUARMState *env, uint64_t addr,
     newv = int128_make128(new_lo, new_hi);
 
     if (parallel) {
-#ifndef CONFIG_CMPXCHG128 // SNPS changed
+#ifndef HAVE_CMPXCHG128 // SNPS changed
         cpu_loop_exit_atomic(env_cpu(env), ra);
 #else
         int mem_idx = cpu_mmu_index(env, false);


### PR DESCRIPTION
CONFIG_CMPXCHG128 is not set when the host CPU has ATOMIC128. In these cases
HAVE_CMPXCHG128 is defined. Therefore HAVE_CMPXCH128 should be checked
instead of CONFIG_CMPXCHG128.

In general, this is only a compile time check and assumes that the host this runs on has the same features as the host that it was compiled on.

Best regards,
Lukas